### PR TITLE
feat: Add save blood pressure samples and clinical records methods

### DIFF
--- a/RCTAppleHealthKit.xcodeproj/project.pbxproj
+++ b/RCTAppleHealthKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3774C8D71D20C65F0000B3F3 /* RCTAppleHealthKit+Methods_Fitness.m in Sources */ = {isa = PBXBuildFile; fileRef = 3774C8D61D20C65F0000B3F3 /* RCTAppleHealthKit+Methods_Fitness.m */; };
 		377D44F31D247D0A004E35CB /* RCTAppleHealthKit+Methods_Characteristic.m in Sources */ = {isa = PBXBuildFile; fileRef = 377D44F21D247D0A004E35CB /* RCTAppleHealthKit+Methods_Characteristic.m */; };
 		37837E7D1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m in Sources */ = {isa = PBXBuildFile; fileRef = 37837E7C1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m */; };
+		48F67D152E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F67D142E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.m */; };
 		4F8095C92523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8095C82523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m */; };
 		58C81E6F1F84F6970005DD48 /* RCTAppleHealthKit+Methods_Activity.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C81E6D1F84F6970005DD48 /* RCTAppleHealthKit+Methods_Activity.m */; };
 		61232F931E303758000A5026 /* RCTAppleHealthKit+Methods_Mindfulness.m in Sources */ = {isa = PBXBuildFile; fileRef = 61232F921E303758000A5026 /* RCTAppleHealthKit+Methods_Mindfulness.m */; };
@@ -61,6 +62,8 @@
 		377D44F21D247D0A004E35CB /* RCTAppleHealthKit+Methods_Characteristic.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_Characteristic.m"; sourceTree = "<group>"; };
 		37837E7B1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit+Methods_Sleep.h"; sourceTree = "<group>"; };
 		37837E7C1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_Sleep.m"; sourceTree = "<group>"; };
+		48F67D132E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthkit+Methods_Clinics.h"; sourceTree = "<group>"; };
+		48F67D142E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthkit+Methods_Clinics.m"; sourceTree = "<group>"; };
 		4F8095C72523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit+Methods_LabTests.h"; sourceTree = "<group>"; };
 		4F8095C82523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_LabTests.m"; sourceTree = "<group>"; };
 		58C81E6D1F84F6970005DD48 /* RCTAppleHealthKit+Methods_Activity.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_Activity.m"; sourceTree = "<group>"; };
@@ -141,6 +144,8 @@
 				27B60164269770850034AB4E /* RCTAppleHealthKit+Methods_Summary.m */,
 				8C79D95E268E07DB00DBDC40 /* RCTAppleHealthKit+Methods_ClinicalRecords.h */,
 				8C79D95F268E081A00DBDC40 /* RCTAppleHealthKit+Methods_ClinicalRecords.m */,
+				48F67D132E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.h */,
+				48F67D142E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.m */,
 			);
 			path = RCTAppleHealthKit;
 			sourceTree = "<group>";
@@ -202,6 +207,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48F67D152E57022D00FD9B71 /* RCTAppleHealthkit+Methods_Clinics.m in Sources */,
 				3774C89B1D2095450000B3F3 /* RCTAppleHealthKit+Queries.m in Sources */,
 				3774C8A11D20A6B90000B3F3 /* RCTAppleHealthKit+Utils.m in Sources */,
 				8C640F40269DF69C004CAFED /* RCTAppleHealthKit+Methods_Hearing.m in Sources */,

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.h
@@ -15,6 +15,7 @@
 - (void)vitals_getWalkingHeartRateAverage:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getBodyTemperatureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getBloodPressureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)vitals_saveBloodPressureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getRespiratoryRateSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getRestingHeartRateSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getHeartRateVariabilitySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
@@ -400,6 +400,37 @@
     }];
 }
 
+- (void)vitals_saveBloodPressureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+
+    NSDate *sampleDate = [RCTAppleHealthKit dateFromOptionsDefaultNow:input];
+
+    // Build systolic object
+    double systolic = [RCTAppleHealthKit doubleFromOptions:input key:@"systolic" withDefault:0];
+    HKQuantityType *systolicType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodPressureSystolic];
+    HKQuantity *systolicQuantity = [HKQuantity quantityWithUnit:[HKUnit millimeterOfMercuryUnit] doubleValue:systolic];
+    HKQuantitySample *systolicSample = [HKQuantitySample quantitySampleWithType:systolicType quantity:systolicQuantity startDate:sampleDate endDate:sampleDate];
+    
+    // Build diastolic object
+    double diastolic = [RCTAppleHealthKit doubleFromOptions:input key:@"diastolic" withDefault:0];
+    HKQuantityType *diastolicType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodPressureDiastolic];
+    HKQuantity *diastolicQuantity = [HKQuantity quantityWithUnit:[HKUnit millimeterOfMercuryUnit] doubleValue:diastolic];
+    HKQuantitySample *diastolicSample = [HKQuantitySample quantitySampleWithType:diastolicType quantity:diastolicQuantity startDate:sampleDate endDate:sampleDate];
+
+    HKCorrelationType *bloodPressureType = [HKObjectType correlationTypeForIdentifier:HKCorrelationTypeIdentifierBloodPressure];
+    NSSet *bloodObjects = [NSSet setWithObjects:systolicSample, diastolicSample, nil];
+
+    HKCorrelation *bloodPressure = [HKCorrelation correlationWithType:bloodPressureType startDate:sampleDate endDate:sampleDate objects:bloodObjects];
+
+    [self.healthStore saveObject:bloodPressure withCompletion:^(BOOL success, NSError *error) {
+        if (!success) {
+            NSLog(@"error saving the blood pressure sample: %@", error);
+            callback(@[RCTMakeError(@"error saving the blood pressure sample", error, nil)]);
+            return;
+        }
+        callback(@[[NSNull null], @(systolic)]);
+    }];
+}
 
 - (void)vitals_getRespiratoryRateSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -23,6 +23,7 @@
 #import "RCTAppleHealthKit+Methods_Hearing.h"
 #import "RCTAppleHealthKit+Methods_Summary.h"
 #import "RCTAppleHealthKit+Methods_ClinicalRecords.h"
+#import "RCTAppleHealthkit+Methods_Clinics.h"
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
@@ -435,6 +436,11 @@ RCT_EXPORT_METHOD(getBloodPressureSamples:(NSDictionary *)input callback:(RCTRes
     [self vitals_getBloodPressureSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(saveBloodPressureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self vitals_saveBloodPressureSamples:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getRespiratoryRateSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];
@@ -601,6 +607,37 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
 {
     [self _initializeHealthStore];
     [self clinicalRecords_getClinicalRecords:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(getMedicationRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getMedications:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(getConditionRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getConditions:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(getAllergyRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getAllergyRecords:input callback:callback];
+}
+RCT_EXPORT_METHOD(getImmunizationRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getImmunizationRecords:input callback:callback];
+}
+RCT_EXPORT_METHOD(getProcedureRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getProcedureRecords:input callback:callback];
+}
+RCT_EXPORT_METHOD(getLabRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getLabRecords:input callback:callback];
+}
+RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self clinics_getClinicalVitalsRecords:input callback:callback];
 }
 
 - (HKHealthStore *)_initializeHealthStore {

--- a/RCTAppleHealthKit/RCTAppleHealthkit+Methods_Clinics.h
+++ b/RCTAppleHealthKit/RCTAppleHealthkit+Methods_Clinics.h
@@ -1,0 +1,21 @@
+//
+//  RCTAppleHealthkit+Methods_Clinics.h
+//  RCTAppleHealthKit
+//
+//  Created by Yair Pinchasi on 21/08/2025.
+//  Copyright © 2025 Greg Wilson. All rights reserved.
+//
+
+#import "RCTAppleHealthKit.h"
+
+@interface RCTAppleHealthKit (Methods_Clinics)
+
+- (void)clinics_getMedications:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getConditions:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getAllergyRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getImmunizationRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getProcedureRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getLabRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)clinics_getClinicalVitalsRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+
+@end

--- a/RCTAppleHealthKit/RCTAppleHealthkit+Methods_Clinics.m
+++ b/RCTAppleHealthKit/RCTAppleHealthkit+Methods_Clinics.m
@@ -1,0 +1,141 @@
+//
+//  RCTAppleHealthkit+Methods_Clinics.m
+//  RCTAppleHealthKit
+//
+//  Created by Yair Pinchasi on 21/08/2025.
+//  Copyright © 2025 Greg Wilson. All rights reserved.
+//
+
+#import "RCTAppleHealthkit+Methods_Clinics.h"
+#import "RCTAppleHealthKit+Queries.h"
+#import "RCTAppleHealthKit+Utils.h"
+
+@implementation RCTAppleHealthKit (Methods_Clinics)
+
+- (void)clinics_getMedications:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierMedicationRecord]
+                 predicate:nil
+                 ascending:false
+                     limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting medications: %@", error);
+                                  callback(@[RCTMakeError(@"error getting medications", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getConditions:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierConditionRecord]
+               predicate:nil
+               ascending:false
+                   limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting conditions: %@", error);
+                                  callback(@[RCTMakeError(@"error getting conditions", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getAllergyRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierAllergyRecord]
+               predicate:nil
+               ascending:false
+                   limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting allergies: %@", error);
+                                  callback(@[RCTMakeError(@"error getting allergies", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getImmunizationRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierImmunizationRecord]
+               predicate:nil
+               ascending:false
+                   limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting immunizations: %@", error);
+                                  callback(@[RCTMakeError(@"error getting immunizations", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getProcedureRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierProcedureRecord]
+               predicate:nil
+               ascending:false
+                   limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting procedures: %@", error);
+                                  callback(@[RCTMakeError(@"error getting procedures", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getLabRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierLabResultRecord]
+                    predicate:nil
+                    ascending:false
+                        limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting lab records: %@", error);
+                                  callback(@[RCTMakeError(@"error getting lab records", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+- (void)clinics_getClinicalVitalsRecords:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    [self fetchClinicalRecordsOfType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierVitalSignRecord]
+               predicate:nil
+               ascending:false
+                   limit:HKObjectQueryNoLimit
+                          completion:^(NSArray *results, NSError *error) {
+                              if(results){
+                                  callback(@[[NSNull null], results]);
+                                  return;
+                              } else {
+                                  NSLog(@"error getting clinical vitals: %@", error);
+                                  callback(@[RCTMakeError(@"error getting clinical vitals", nil, nil)]);
+                                  return;
+                              }
+                          }];
+}
+
+@end

--- a/index.d.ts
+++ b/index.d.ts
@@ -295,6 +295,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: Array<BloodPressureSampleValue>) => void,
     ): void
 
+    saveBloodPressureSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<BloodPressureSampleValue>) => void,
+    ): void
+
     getRespiratoryRateSamples(
       options: HealthInputOptions,
       callback: (err: string, results: Array<HealthValue>) => void,
@@ -462,6 +467,40 @@ declare module 'react-native-health' {
       callback: (error: string, result: HealthValue) => void,
     ): void
 
+    getMedicationRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getConditionRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getAllergyRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getImmunizationRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getProcedureRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getLabRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getClinicalVitalRecords(
+      options: HealthInputOptions | null,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
 
     Constants: Constants
   }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,125 @@
 import { Activities, Observers, Permissions, Units } from './src/constants'
+import { Platform } from 'react-native'
+
 
 const { AppleHealthKit } = require('react-native').NativeModules
 
-export const HealthKit = Object.assign({}, AppleHealthKit, {
-  Constants: {
-    Activities,
-    Observers,
-    Permissions,
-    Units,
-  },
-})
+export const HealthKit =
+  Platform.OS !== 'ios'
+    ? {}
+    : {
+        initHealthKit: AppleHealthKit.initHealthKit,
+        isAvailable: AppleHealthKit.isAvailable,
+        getBiologicalSex: AppleHealthKit.getBiologicalSex,
+        getBloodType: AppleHealthKit.getBloodType,
+        getDateOfBirth: AppleHealthKit.getDateOfBirth,
+        getLatestWeight: AppleHealthKit.getLatestWeight,
+        getWeightSamples: AppleHealthKit.getWeightSamples,
+        saveWeight: AppleHealthKit.saveWeight,
+        getLatestHeight: AppleHealthKit.getLatestHeight,
+        getHeightSamples: AppleHealthKit.getHeightSamples,
+        saveHeight: AppleHealthKit.saveHeight,
+        getLatestWaistCircumference: AppleHealthKit.getLatestWaistCircumference,
+        getWaistCircumferenceSamples:
+          AppleHealthKit.getWaistCircumferenceSamples,
+        saveWaistCircumference: AppleHealthKit.saveWaistCircumference,
+        getLatestPeakFlow: AppleHealthKit.getLatestPeakFlow,
+        getPeakFlowSamples: AppleHealthKit.getPeakFlowSamples,
+        savePeakFlow: AppleHealthKit.savePeakFlow,
+        saveLeanBodyMass: AppleHealthKit.saveLeanBodyMass,
+        getLatestBmi: AppleHealthKit.getLatestBmi,
+        getBmiSamples: AppleHealthKit.getBmiSamples,
+        saveBmi: AppleHealthKit.saveBmi,
+        getLatestBodyFatPercentage: AppleHealthKit.getLatestBodyFatPercentage,
+        getBodyFatPercentageSamples: AppleHealthKit.getBodyFatPercentageSamples,
+        getLatestLeanBodyMass: AppleHealthKit.getLatestLeanBodyMass,
+        getLeanBodyMassSamples: AppleHealthKit.getLeanBodyMassSamples,
+        getStepCount: AppleHealthKit.getStepCount,
+        getSamples: AppleHealthKit.getSamples,
+        getAnchoredWorkouts: AppleHealthKit.getAnchoredWorkouts,
+        getDailyStepCountSamples: AppleHealthKit.getDailyStepCountSamples,
+        saveSteps: AppleHealthKit.saveSteps,
+        saveWalkingRunningDistance: AppleHealthKit.saveWalkingRunningDistance,
+        getDistanceWalkingRunning: AppleHealthKit.getDistanceWalkingRunning,
+        getDailyDistanceWalkingRunningSamples:
+          AppleHealthKit.getDailyDistanceWalkingRunningSamples,
+        getDistanceCycling: AppleHealthKit.getDistanceCycling,
+        getDailyDistanceCyclingSamples:
+          AppleHealthKit.getDailyDistanceCyclingSamples,
+        getFlightsClimbed: AppleHealthKit.getFlightsClimbed,
+        getDailyFlightsClimbedSamples:
+          AppleHealthKit.getDailyFlightsClimbedSamples,
+        getEnergyConsumedSamples: AppleHealthKit.getEnergyConsumedSamples,
+        getProteinSamples: AppleHealthKit.getProteinSamples,
+        getFiberSamples: AppleHealthKit.getFiberSamples,
+        getTotalFatSamples: AppleHealthKit.getTotalFatSamples,
+        saveFood: AppleHealthKit.saveFood,
+        saveWater: AppleHealthKit.saveWater,
+        getWater: AppleHealthKit.getWater,
+        saveHeartRateSample: AppleHealthKit.saveHeartRateSample,
+        getWaterSamples: AppleHealthKit.getWaterSamples,
+        getHeartRateSamples: AppleHealthKit.getHeartRateSamples,
+        getRestingHeartRate: AppleHealthKit.getRestingHeartRate,
+        getWalkingHeartRateAverage: AppleHealthKit.getWalkingHeartRateAverage,
+        getActiveEnergyBurned: AppleHealthKit.getActiveEnergyBurned,
+        getBasalEnergyBurned: AppleHealthKit.getBasalEnergyBurned,
+        getAppleExerciseTime: AppleHealthKit.getAppleExerciseTime,
+        getAppleStandTime: AppleHealthKit.getAppleStandTime,
+        getVo2MaxSamples: AppleHealthKit.getVo2MaxSamples,
+        getBodyTemperatureSamples: AppleHealthKit.getBodyTemperatureSamples,
+        getBloodPressureSamples: AppleHealthKit.getBloodPressureSamples,
+        saveBloodPressureSamples: AppleHealthKit.saveBloodPressureSamples,
+        getRespiratoryRateSamples: AppleHealthKit.getRespiratoryRateSamples,
+        getHeartRateVariabilitySamples:
+          AppleHealthKit.getHeartRateVariabilitySamples,
+        getHeartbeatSeriesSamples: AppleHealthKit.getHeartbeatSeriesSamples,
+        getRestingHeartRateSamples: AppleHealthKit.getRestingHeartRateSamples,
+        getBloodGlucoseSamples: AppleHealthKit.getBloodGlucoseSamples,
+        getCarbohydratesSamples: AppleHealthKit.getCarbohydratesSamples,
+        saveBloodGlucoseSample: AppleHealthKit.saveBloodGlucoseSample,
+        saveCarbohydratesSample: AppleHealthKit.saveCarbohydratesSample,
+        deleteBloodGlucoseSample: AppleHealthKit.deleteBloodGlucoseSample,
+        deleteCarbohydratesSample: AppleHealthKit.deleteCarbohydratesSample,
+        getSleepSamples: AppleHealthKit.getSleepSamples,
+        getInfo: AppleHealthKit.getInfo,
+        getMindfulSession: AppleHealthKit.getMindfulSession,
+        saveMindfulSession: AppleHealthKit.saveMindfulSession,
+        getWorkoutRouteSamples: AppleHealthKit.getWorkoutRouteSamples,
+        saveWorkout: AppleHealthKit.saveWorkout,
+        getAuthStatus: AppleHealthKit.getAuthStatus,
+        getLatestBloodAlcoholContent:
+          AppleHealthKit.getLatestBloodAlcoholContent,
+        getBloodAlcoholContentSamples:
+          AppleHealthKit.getBloodAlcoholContentSamples,
+        saveBloodAlcoholContent: AppleHealthKit.saveBloodAlcoholContent,
+        getDistanceSwimming: AppleHealthKit.getDistanceSwimming,
+        getDailyDistanceSwimmingSamples:
+          AppleHealthKit.getDailyDistanceSwimmingSamples,
+        getOxygenSaturationSamples: AppleHealthKit.getOxygenSaturationSamples,
+        getElectrocardiogramSamples: AppleHealthKit.getElectrocardiogramSamples,
+        saveBodyFatPercentage: AppleHealthKit.saveBodyFatPercentage,
+        saveBodyTemperature: AppleHealthKit.saveBodyTemperature,
+        getEnvironmentalAudioExposure:
+          AppleHealthKit.getEnvironmentalAudioExposure,
+        getHeadphoneAudioExposure: AppleHealthKit.getHeadphoneAudioExposure,
+        getClinicalRecords: AppleHealthKit.getClinicalRecords,
+        getActivitySummary: AppleHealthKit.getActivitySummary,
+        getInsulinDeliverySamples: AppleHealthKit.getInsulinDeliverySamples,
+        saveInsulinDeliverySample: AppleHealthKit.saveInsulinDeliverySample,
+        deleteInsulinDeliverySample: AppleHealthKit.deleteInsulinDeliverySample,
+        getMedicationRecords: AppleHealthKit.getMedicationRecords,
+        getConditionRecords: AppleHealthKit.getConditionRecords,
+        getAllergyRecords: AppleHealthKit.getAllergyRecords,
+        getImmunizationRecords: AppleHealthKit.getImmunizationRecords,
+        getProcedureRecords: AppleHealthKit.getProcedureRecords,
+        getLabRecords: AppleHealthKit.getLabRecords,
+        getClinicalVitalRecords: AppleHealthKit.getClinicalVitalRecords,
+        Constants: {
+          Activities,
+          Observers,
+          Permissions,
+          Units,
+        },
+      }
 
 module.exports = HealthKit


### PR DESCRIPTION
## 🧠 Summary
This PR introduces the ability to save blood pressure samples to Apple Health and retrieves clinical records. It adds a new method for saving blood pressure and includes support for fetching medication, condition, allergy, immunization, procedure, lab, and clinical vital records.

## ✅ Changes
*   Adds `saveBloodPressureSamples` method to `RCTAppleHealthKit+Methods_Vitals.h` and `RCTAppleHealthKit+Methods_Vitals.m` to save blood pressure data.
*   Adds `RCTAppleHealthkit+Methods_Clinics.h` and `RCTAppleHealthkit+Methods_Clinics.m` to handle clinical record queries.
*   Adds new methods in `RCTAppleHealthKit.m` to expose the new functionality.
*   Adds definitions for the new methods to `index.d.ts`.
*   Adds conditions to only expose HealthKit on iOS