### PR TITLE
RND-33794 |  HealthKit background delivery never fired

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -502,6 +502,10 @@
     } else {
         sampleType = [RCTAppleHealthKit quantityTypeFromName:type];
     }
+    if (!sampleType) {
+        NSLog(@"[HealthKit] Skipping observer for unknown type: %@", type);
+        return;
+    }
     [self setObserverForType:sampleType type:type bridge:bridge];
 }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -497,9 +497,12 @@
                           bridge:(RCTBridge *)bridge
 {
     HKSampleType *sampleType;
+    // HKCategoryType observers must be resolved explicitly — quantityTypeFromName only handles
+    // quantity and workout types. Adding a new category type (e.g. HandwashingEvent) without
+    // a branch here will silently skip its observer via the nil-guard below.
     if ([type isEqualToString:@"SleepAnalysis"]) {
         sampleType = [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierSleepAnalysis];
-    } else if ([type isEqualToString:@"MindfulSession"]) {
+    } else if ([type isEqualToString:@"MindfulSession"]) { // HKCategoryType — not resolvable via quantityTypeFromName
         sampleType = [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierMindfulSession];
     } else {
         sampleType = [RCTAppleHealthKit quantityTypeFromName:type];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -499,6 +499,8 @@
     HKSampleType *sampleType;
     if ([type isEqualToString:@"SleepAnalysis"]) {
         sampleType = [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierSleepAnalysis];
+    } else if ([type isEqualToString:@"MindfulSession"]) {
+        sampleType = [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierMindfulSession];
     } else {
         sampleType = [RCTAppleHealthKit quantityTypeFromName:type];
     }

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -271,13 +271,15 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     // AppDelegate hooks (sourceURL:, RCTJavaScriptDidLoad) don't fire under Expo New Arch —
     // this is the only guaranteed JS-reachable entry point on this setup.
     // Uses a BOOL ivar (not dispatch_once) so a nil-bridge first call can retry on the next call.
-    if (!_observersInitialized) {
-        if (self.bridge) {
-            NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
-            [self initializeBackgroundObservers:self.bridge];
-            _observersInitialized = YES;
-        } else {
-            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
+    @synchronized(self) {
+        if (!_observersInitialized) {
+            if (self.bridge) {
+                NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
+                [self initializeBackgroundObservers:self.bridge];
+                _observersInitialized = YES;
+            } else {
+                NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
+            }
         }
     }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -296,8 +296,9 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
         NSTimeInterval seconds;
         if ([interval isKindOfClass:[NSNumber class]]) {
             double raw = [interval doubleValue];
-            // Reject NaN/Infinity/zero/negative — fall back to 24h default.
-            seconds = (isfinite(raw) && raw > 0) ? raw : 86400.0;
+            // Round floats to nearest integer, clamp to 1s minimum.
+            // Non-finite, zero, or negative values fall back to 24h default.
+            seconds = (isfinite(raw) && raw > 0) ? MAX(1.0, round(raw)) : 86400.0;
         } else if ([interval isKindOfClass:[NSString class]]) {
             seconds = [RCTAppleHealthKit syncIntervalFromString:(NSString *)interval];
         } else {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -31,7 +31,9 @@
 #import <React/RCTEventDispatcher.h>
 
 
-@implementation RCTAppleHealthKit
+@implementation RCTAppleHealthKit {
+    BOOL _observersInitialized;
+}
 
 bool hasListeners;
 
@@ -251,7 +253,6 @@ RCT_EXPORT_METHOD(getAnchoredWorkouts:(NSDictionary *)input callback:(RCTRespons
 }
 
 + (NSTimeInterval)syncIntervalFromString:(NSString *)interval {
-    if ([interval isEqualToString:@"every1minute"]) return 60.0;
     if ([interval isEqualToString:@"every1hour"])   return 3600.0;
     if ([interval isEqualToString:@"every6hours"])  return 21600.0;
     if ([interval isEqualToString:@"every12hours"]) return 43200.0;
@@ -268,15 +269,16 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     // Lazily wire background observers the first time JS calls configureBackgroundSync.
     // AppDelegate hooks (sourceURL:, RCTJavaScriptDidLoad) don't fire under Expo New Arch —
     // this is the only guaranteed JS-reachable entry point on this setup.
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    // Uses a BOOL ivar (not dispatch_once) so a nil-bridge first call can retry on the next call.
+    if (!_observersInitialized) {
         if (self.bridge) {
             NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
             [self initializeBackgroundObservers:self.bridge];
+            _observersInitialized = YES;
         } else {
-            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered");
+            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
         }
-    });
+    }
 
     // Default to NO (opt-in) to match observer behavior: "Defaults to disabled if the key
     // was never written". Caller must explicitly pass enabled: true to enable background sync.
@@ -292,7 +294,8 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     if (interval) {
         NSTimeInterval seconds;
         if ([interval isKindOfClass:[NSNumber class]]) {
-            seconds = [interval doubleValue];
+            // Clamp to 1s minimum — 0, negative, or NaN values are rejected.
+            seconds = MAX(1.0, [interval doubleValue]);
         } else {
             seconds = [RCTAppleHealthKit syncIntervalFromString:(NSString *)interval];
         }

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -264,6 +264,20 @@ RCT_EXPORT_METHOD(getAnchoredWorkouts:(NSDictionary *)input callback:(RCTRespons
 RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
 {
     [self _initializeHealthStore];
+
+    // Lazily wire background observers the first time JS calls configureBackgroundSync.
+    // AppDelegate hooks (sourceURL:, RCTJavaScriptDidLoad) don't fire under Expo New Arch —
+    // this is the only guaranteed JS-reachable entry point on this setup.
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (self.bridge) {
+            NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
+            [self initializeBackgroundObservers:self.bridge];
+        } else {
+            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered");
+        }
+    });
+
     // Default to NO (opt-in) to match observer behavior: "Defaults to disabled if the key
     // was never written". Caller must explicitly pass enabled: true to enable background sync.
     BOOL enabled = [input objectForKey:@"enabled"]
@@ -273,9 +287,15 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
 
     // Always persist syncInterval so it survives enable/disable cycles.
     // Stored even when disabled so re-enabling later uses the correct value.
-    NSString *interval = [input objectForKey:@"syncInterval"];
+    // Accepts either a named string alias ('every1hour', …) or a raw NSNumber of seconds.
+    id interval = [input objectForKey:@"syncInterval"];
     if (interval) {
-        NSTimeInterval seconds = [RCTAppleHealthKit syncIntervalFromString:interval];
+        NSTimeInterval seconds;
+        if ([interval isKindOfClass:[NSNumber class]]) {
+            seconds = [interval doubleValue];
+        } else {
+            seconds = [RCTAppleHealthKit syncIntervalFromString:(NSString *)interval];
+        }
         [[NSUserDefaults standardUserDefaults] setDouble:seconds forKey:@"RNHealth_SyncInterval"];
         NSLog(@"[HealthKit] Background sync %@, interval %.0fs", enabled ? @"enabled" : @"disabled", seconds);
     } else {
@@ -1102,12 +1122,13 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
 // Will be called when this module's first listener is added.
 -(void)startObserving {
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-        for (NSString *notificationName in [self supportedEvents]) {
-            [center addObserver:self
-                   selector:@selector(emitEventInternal:)
-                       name:notificationName
-                     object:nil];
-        }
+    [center removeObserver:self];
+    for (NSString *notificationName in [self supportedEvents]) {
+        [center addObserver:self
+               selector:@selector(emitEventInternal:)
+                   name:notificationName
+                 object:nil];
+    }
     self.hasListeners = YES;
 }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -259,6 +259,7 @@ RCT_EXPORT_METHOD(getAnchoredWorkouts:(NSDictionary *)input callback:(RCTRespons
     if ([interval isEqualToString:@"every24hours"]) return 86400.0;
     if ([interval isEqualToString:@"every48hours"]) return 172800.0;
     if ([interval isEqualToString:@"everyweek"])    return 604800.0;
+    NSLog(@"[HealthKit] syncInterval: unrecognized string '%@', falling back to 86400s", interval);
     return 86400.0;
 }
 
@@ -294,10 +295,14 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     if (interval) {
         NSTimeInterval seconds;
         if ([interval isKindOfClass:[NSNumber class]]) {
-            // Clamp to 1s minimum — 0, negative, or NaN values are rejected.
-            seconds = MAX(1.0, [interval doubleValue]);
-        } else {
+            double raw = [interval doubleValue];
+            // Reject NaN/Infinity (isfinite), clamp negatives and zero to 1s.
+            seconds = (isfinite(raw) && raw > 0) ? raw : 1.0;
+        } else if ([interval isKindOfClass:[NSString class]]) {
             seconds = [RCTAppleHealthKit syncIntervalFromString:(NSString *)interval];
+        } else {
+            NSLog(@"[HealthKit] syncInterval: unexpected type %@, using default 86400s", NSStringFromClass([interval class]));
+            seconds = 86400.0;
         }
         [[NSUserDefaults standardUserDefaults] setDouble:seconds forKey:@"RNHealth_SyncInterval"];
         NSLog(@"[HealthKit] Background sync %@, interval %.0fs", enabled ? @"enabled" : @"disabled", seconds);

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -29,10 +29,12 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
+#import <os/lock.h>
 
 
 @implementation RCTAppleHealthKit {
     BOOL _observersInitialized;
+    os_unfair_lock _initLock;
 }
 
 bool hasListeners;
@@ -271,17 +273,17 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     // AppDelegate hooks (sourceURL:, RCTJavaScriptDidLoad) don't fire under Expo New Arch —
     // this is the only guaranteed JS-reachable entry point on this setup.
     // Uses a BOOL ivar (not dispatch_once) so a nil-bridge first call can retry on the next call.
-    @synchronized(self) {
-        if (!_observersInitialized) {
-            if (self.bridge) {
-                NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
-                [self initializeBackgroundObservers:self.bridge];
-                _observersInitialized = YES;
-            } else {
-                NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
-            }
+    os_unfair_lock_lock(&_initLock);
+    if (!_observersInitialized) {
+        if (self.bridge) {
+            NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
+            [self initializeBackgroundObservers:self.bridge];
+            _observersInitialized = YES;
+        } else {
+            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
         }
     }
+    os_unfair_lock_unlock(&_initLock);
 
     // Default to NO (opt-in) to match observer behavior: "Defaults to disabled if the key
     // was never written". Caller must explicitly pass enabled: true to enable background sync.

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -1130,8 +1130,8 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
 // Will be called when this module's first listener is added.
 -(void)startObserving {
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center removeObserver:self];
     for (NSString *notificationName in [self supportedEvents]) {
+        [center removeObserver:self name:notificationName object:nil];
         [center addObserver:self
                selector:@selector(emitEventInternal:)
                    name:notificationName

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -296,8 +296,8 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
         NSTimeInterval seconds;
         if ([interval isKindOfClass:[NSNumber class]]) {
             double raw = [interval doubleValue];
-            // Reject NaN/Infinity (isfinite), clamp negatives and zero to 1s.
-            seconds = (isfinite(raw) && raw > 0) ? raw : 1.0;
+            // Reject NaN/Infinity/zero/negative — fall back to 24h default.
+            seconds = (isfinite(raw) && raw > 0) ? raw : 86400.0;
         } else if ([interval isKindOfClass:[NSString class]]) {
             seconds = [RCTAppleHealthKit syncIntervalFromString:(NSString *)interval];
         } else {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -251,6 +251,7 @@ RCT_EXPORT_METHOD(getAnchoredWorkouts:(NSDictionary *)input callback:(RCTRespons
 }
 
 + (NSTimeInterval)syncIntervalFromString:(NSString *)interval {
+    if ([interval isEqualToString:@"every1minute"]) return 60.0;
     if ([interval isEqualToString:@"every1hour"])   return 3600.0;
     if ([interval isEqualToString:@"every6hours"])  return 21600.0;
     if ([interval isEqualToString:@"every12hours"]) return 43200.0;

--- a/docs/configureBackgroundSync.md
+++ b/docs/configureBackgroundSync.md
@@ -29,6 +29,12 @@ Either a named alias or a raw **number of seconds**:
 | `'everyweek'` | 604800 |
 | `number` | any positive value, e.g. `60` for 1 minute |
 
+### Input validation
+
+- **Unrecognized string** — falls back to `86400s` (24 hours) and logs a warning.
+- **Invalid number** (zero, negative, NaN, Infinity) — clamped to `1s` minimum.
+- **Wrong type** (not string or number) — falls back to `86400s` and logs a warning.
+
 ## Examples
 
 ```js

--- a/docs/configureBackgroundSync.md
+++ b/docs/configureBackgroundSync.md
@@ -32,7 +32,7 @@ Either a named alias or a raw **number of seconds**:
 ### Input validation
 
 - **Unrecognized string** — falls back to `86400s` (24 hours) and logs a warning.
-- **Invalid number** (zero, negative, NaN, Infinity) — clamped to `1s` minimum.
+- **Invalid number** (zero, negative, NaN, Infinity) — defaults to `86400s` (24 hours).
 - **Wrong type** (not string or number) — falls back to `86400s` and logs a warning.
 
 ## Examples

--- a/docs/configureBackgroundSync.md
+++ b/docs/configureBackgroundSync.md
@@ -27,11 +27,12 @@ Either a named alias or a raw **number of seconds**:
 | `'every24hours'` | 86400 |
 | `'every48hours'` | 172800 |
 | `'everyweek'` | 604800 |
-| `number` | any positive value, e.g. `60` for 1 minute |
+| `number` | positive seconds, e.g. `60` for 1 minute; floats are rounded to nearest integer |
 
 ### Input validation
 
 - **Unrecognized string** — falls back to `86400s` (24 hours) and logs a warning.
+- **Float** — rounded to nearest integer, minimum `1s` (e.g. `1.5` → `2`, `0.3` → `1`).
 - **Invalid number** (zero, negative, NaN, Infinity) — defaults to `86400s` (24 hours).
 - **Wrong type** (not string or number) — falls back to `86400s` and logs a warning.
 

--- a/docs/configureBackgroundSync.md
+++ b/docs/configureBackgroundSync.md
@@ -5,7 +5,7 @@ Configure the minimum interval between background delta fetches. Call this once 
 ## Signature
 
 ```js
-AppleHealthKit.configureBackgroundSync(options, callback)
+AppleHealthKit.configureBackgroundSync(options)
 ```
 
 ## Options
@@ -13,21 +13,36 @@ AppleHealthKit.configureBackgroundSync(options, callback)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Enable or disable background sync |
-| `syncInterval` | `SyncInterval` | `'every24hours'` | Minimum time between delta fetches |
+| `syncInterval` | `SyncInterval \| number` | `'every24hours'` | Minimum time between delta fetches |
 
-`SyncInterval` values: `'every1hour'`, `'every6hours'`, `'every12hours'`, `'every24hours'`, `'every48hours'`, `'everyweek'`
+### SyncInterval
 
-## Example
+Either a named alias or a raw **number of seconds**:
+
+| Alias | Seconds |
+|-------|---------|
+| `'every1hour'` | 3600 |
+| `'every6hours'` | 21600 |
+| `'every12hours'` | 43200 |
+| `'every24hours'` | 86400 |
+| `'every48hours'` | 172800 |
+| `'everyweek'` | 604800 |
+| `number` | any positive value, e.g. `60` for 1 minute |
+
+## Examples
 
 ```js
 import AppleHealthKit from 'react-native-health'
 
-AppleHealthKit.configureBackgroundSync(
-  { enabled: true, syncInterval: 'every6hours' },
-  (err) => {
-    if (err) console.error('configureBackgroundSync error:', err)
-  }
-)
+// Named alias
+AppleHealthKit.configureBackgroundSync({ enabled: true, syncInterval: 'every6hours' })
+
+// Raw seconds — useful for testing or non-standard intervals
+AppleHealthKit.configureBackgroundSync({ enabled: true, syncInterval: 60 })   // 1 minute
+AppleHealthKit.configureBackgroundSync({ enabled: true, syncInterval: 300 })  // 5 minutes
+
+// Disable
+AppleHealthKit.configureBackgroundSync({ enabled: false })
 ```
 
 ## Notes

--- a/index.d.ts
+++ b/index.d.ts
@@ -951,7 +951,7 @@ declare module 'react-native-health' {
 
   export interface BackgroundSyncOptions {
     enabled?:      boolean
-    /** Positive finite seconds; zero, negative, NaN, or Infinity default to 86400s (24 hours). */
+    /** Positive seconds; floats rounded to nearest integer (min 1s). Zero, negative, NaN, or Infinity default to 86400s (24 hours). */
     syncInterval?: SyncInterval
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -940,6 +940,11 @@ declare module 'react-native-health' {
    * Minimum time between background delta fetches. Default: `'every24hours'`.
    * Pass a named alias or a raw number of **seconds** (e.g. `60` for 1 minute).
    */
+  /**
+   * Minimum time between background delta fetches. Default: `'every24hours'`.
+   * Pass a named alias or a raw positive number of **seconds** (e.g. `60` for 1 minute).
+   * Floats are rounded to the nearest integer. Zero, negative, NaN, and Infinity fall back to `86400s` at runtime.
+   */
   export type SyncInterval =
     | 'every1hour'
     | 'every6hours'
@@ -947,7 +952,7 @@ declare module 'react-native-health' {
     | 'every24hours'
     | 'every48hours'
     | 'everyweek'
-    | number
+    | number // positive finite integer seconds; invalid values default to 86400s at runtime
 
   export interface BackgroundSyncOptions {
     enabled?:      boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -951,6 +951,7 @@ declare module 'react-native-health' {
 
   export interface BackgroundSyncOptions {
     enabled?:      boolean
+    /** Positive finite seconds; zero, negative, NaN, or Infinity default to 86400s (24 hours). */
     syncInterval?: SyncInterval
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -936,7 +936,10 @@ declare module 'react-native-health' {
     | 'last6months'
     | 'lastyear'
 
-  /** Minimum time between background delta fetches. Default: 'every24hours'. */
+  /**
+   * Minimum time between background delta fetches. Default: `'every24hours'`.
+   * Pass a named alias or a raw number of **seconds** (e.g. `60` for 1 minute).
+   */
   export type SyncInterval =
     | 'every1hour'
     | 'every6hours'
@@ -944,6 +947,7 @@ declare module 'react-native-health' {
     | 'every24hours'
     | 'every48hours'
     | 'everyweek'
+    | number
 
   export interface BackgroundSyncOptions {
     enabled?:      boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -938,10 +938,6 @@ declare module 'react-native-health' {
 
   /**
    * Minimum time between background delta fetches. Default: `'every24hours'`.
-   * Pass a named alias or a raw number of **seconds** (e.g. `60` for 1 minute).
-   */
-  /**
-   * Minimum time between background delta fetches. Default: `'every24hours'`.
    * Pass a named alias or a raw positive number of **seconds** (e.g. `60` for 1 minute).
    * Floats are rounded to the nearest integer. Zero, negative, NaN, and Infinity fall back to `86400s` at runtime.
    */
@@ -952,7 +948,7 @@ declare module 'react-native-health' {
     | 'every24hours'
     | 'every48hours'
     | 'everyweek'
-    | number // positive finite integer seconds; invalid values default to 86400s at runtime
+    | number // must be a positive finite value in seconds; zero, negative, NaN, and Infinity default to 86400s at runtime
 
   export interface BackgroundSyncOptions {
     enabled?:      boolean

--- a/src/constants/SyncIntervals.js
+++ b/src/constants/SyncIntervals.js
@@ -1,7 +1,10 @@
 /**
- * Minimum time between background delta fetches for HealthKit observers.
+ * Named aliases for common background-sync intervals.
  * Pass to configureBackgroundSync({ syncInterval }).
  * Default when omitted: every24Hours.
+ *
+ * You may also pass a raw number of seconds instead of a named alias,
+ * e.g. { syncInterval: 60 } for a 1-minute interval.
  *
  * @type {Object}
  */


### PR DESCRIPTION
## Description

- Adds support for passing a raw number of seconds to `registerHealthBackgroundSync({ syncInterval })`, removing the 1-hour minimum enforced by the previous string-only API
- Updates the Hello-Heart/react-native-health fork with matching native + type changes

## Changes

### @helloheart/core (this repo)

**src/health/backgroundSync.ts**
- `syncInterval` union extended with `number` (seconds)
- `'every1minute'` alias removed — pass `60` directly instead
- JSDoc updated: documents float rounding, valid range, and 86400s fallback for invalid input

**src/health/__tests__/backgroundSync.test.ts**
- 5 new tests: numeric pass-through (60), float pass-through (1.5), edge cases (0, -1), string alias unchanged
- 10 tests total, all passing

**docs/health/background-sync-flexible-interval.md** — new feature doc

**package.json / yarn.lock** — pinned to `react-native-health#RND-33794`

---

### Hello-Heart/react-native-health (RND-33794 branch)

**RCTAppleHealthKit/RCTAppleHealthKit.m**
- `configureBackgroundSync` reads `syncInterval` as `id` — branches on `NSNumber` (raw seconds) vs `NSString` (named alias)
- Numeric values: floats rounded to nearest integer via `MAX(1.0, round(raw))`; zero, negative, NaN, Infinity fall back to `86400s` (24h default)
- All three invalid-input paths (number, string, wrong type) consistently fall back to `86400s`
- Replaced `dispatch_once` lazy-init guard with `_observersInitialized` BOOL ivar — nil-bridge first calls no longer permanently block observer registration
- Removed `every1minute` dead-code branch from `syncIntervalFromString`
- Scoped `NSNotificationCenter` removal in `startObserving` to HealthKit event names only — prevents silently dropping unrelated observers

**RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m**
- Guard against nil `sampleType` in `fitness_registerObserver`
- Fix: `MindfulSession` registered as `HKCategoryType` observer (was silently skipped — background delivery never fired)

**index.d.ts** — `SyncInterval` extended with `| number`; JSDoc documents rounding and fallback behavior

**docs/configureBackgroundSync.md** — updated with numeric usage, float rounding, and input validation details

## Usage

```js
// Testing — any interval in seconds
registerHealthBackgroundSync({ enabled: true, syncInterval: 60 })   // 1 min
registerHealthBackgroundSync({ enabled: true, syncInterval: 300 })  // 5 min

// Production — named aliases unchanged
registerHealthBackgroundSync({ enabled: true, syncInterval: 'every6hours' })
```

## Test Plan

- Run `yarn test src/health/__tests__/backgroundSync.test.ts` — 10/10 pass
- iOS rebuild required after native change (`pod install` + clean build)
- Verify `[HealthKit] Background sync enabled, interval 60s` appears in Xcode console after calling with `syncInterval: 60`
- Verify observer fires within ~1 minute by adding a health sample on device

## Before merging to main

- Tag `react-native-health` branch as a release (e.g. `v1.22.0`)
- Update `package.json` from `#RND-33794` to `#v1.22.0`
- Re-run `yarn install` to update `yarn.lock`