### PR TITLE
RND-33848 | fix(observers): support killed-state HealthKit background delivery

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -26,6 +26,7 @@
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getAuthorizationStatus:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)initializeBackgroundObservers:(RCTBridge *)bridge;
+- (void)initializeBackgroundObservers:(RCTBridge *)bridge metrics:(nullable NSArray<NSString *> *)metrics;
 - (void)emitEventWithName:(NSString *)name andPayload:(NSDictionary *)payload;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -1097,7 +1097,8 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
 }
 
 - (void)initializeBackgroundObservers:(RCTBridge *)bridge {
-    [self initializeBackgroundObservers:bridge metrics:nil];
+    NSArray *savedMetrics = [[NSUserDefaults standardUserDefaults] objectForKey:@"RNHealth_SyncMetrics"];
+    [self initializeBackgroundObservers:bridge metrics:savedMetrics];
 }
 
 - (void)initializeBackgroundObservers:(RCTBridge *)bridge metrics:(NSArray<NSString *> *)metrics {
@@ -1106,7 +1107,6 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
         os_unfair_lock_unlock(&_initLock);
         return;
     }
-    _observersInitialized = YES;
     os_unfair_lock_unlock(&_initLock);
 
     [self _initializeHealthStore];
@@ -1139,7 +1139,11 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
             NSMutableSet *requestedHKTypes = [NSMutableSet set];
             for (NSString *metric in metrics) {
                 NSString *hkType = map[metric];
-                if (hkType) [requestedHKTypes addObject:hkType];
+                if (hkType) {
+                    [requestedHKTypes addObject:hkType];
+                } else {
+                    NSLog(@"[HealthKit] Unknown metric '%@' — not in healthMetricToHKTypeMap, skipping", metric);
+                }
             }
             fitnessToRegister = [allFitnessObservers filteredArrayUsingPredicate:
                 [NSPredicate predicateWithBlock:^BOOL(NSString *type, NSDictionary *_) {
@@ -1178,6 +1182,10 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
     } else {
         NSLog(@"[HealthKit] Apple HealthKit is not available in this platform");
     }
+
+    os_unfair_lock_lock(&_initLock);
+    _observersInitialized = YES;
+    os_unfair_lock_unlock(&_initLock);
 }
 
 // Will be called when this module's first listener is added.

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -273,17 +273,20 @@ RCT_EXPORT_METHOD(configureBackgroundSync:(NSDictionary *)input)
     // AppDelegate hooks (sourceURL:, RCTJavaScriptDidLoad) don't fire under Expo New Arch —
     // this is the only guaranteed JS-reachable entry point on this setup.
     // Uses a BOOL ivar (not dispatch_once) so a nil-bridge first call can retry on the next call.
-    os_unfair_lock_lock(&_initLock);
-    if (!_observersInitialized) {
-        if (self.bridge) {
-            NSLog(@"[HealthKit] configureBackgroundSync — lazily initializing background observers");
-            [self initializeBackgroundObservers:self.bridge];
-            _observersInitialized = YES;
-        } else {
-            NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
-        }
+    // Persist metrics list so AppDelegate can re-register the same types on killed-state launch.
+    NSArray *metrics = [input objectForKey:@"metrics"];
+    if (metrics.count > 0) {
+        [[NSUserDefaults standardUserDefaults] setObject:metrics forKey:@"RNHealth_SyncMetrics"];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"RNHealth_SyncMetrics"];
     }
-    os_unfair_lock_unlock(&_initLock);
+
+    if (self.bridge) {
+        NSLog(@"[HealthKit] configureBackgroundSync — initializing background observers");
+        [self initializeBackgroundObservers:self.bridge metrics:metrics];
+    } else {
+        NSLog(@"[HealthKit] configureBackgroundSync — WARNING: self.bridge is nil, observers NOT registered, will retry");
+    }
 
     // Default to NO (opt-in) to match observer behavior: "Defaults to disabled if the key
     // was never written". Caller must explicitly pass enabled: true to enable background sync.
@@ -1079,17 +1082,39 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
 
     This method must be called at the application:didFinishLaunchingWithOptions: method, in AppDelegate.m
  */
-  - (void)initializeBackgroundObservers:(RCTBridge *)bridge
-{
-    if (_observersInitialized) return;
+// Maps @helloheart/core HealthMetric enum values to native HK type strings.
+// Only includes types present in allFitnessObservers — others are silently ignored.
++ (NSDictionary<NSString *, NSString *> *)healthMetricToHKTypeMap {
+    return @{
+        @"heartRate":        @"HeartRate",
+        @"restingHeartRate": @"RestingHeartRate",
+        @"hrv":              @"HeartRateVariabilitySDNN",
+        @"steps":            @"StepCount",
+        @"activeEnergy":     @"ActiveEnergyBurned",
+        @"sleep":            @"SleepAnalysis",
+        @"vo2Max":           @"Vo2Max",
+    };
+}
+
+- (void)initializeBackgroundObservers:(RCTBridge *)bridge {
+    [self initializeBackgroundObservers:bridge metrics:nil];
+}
+
+- (void)initializeBackgroundObservers:(RCTBridge *)bridge metrics:(NSArray<NSString *> *)metrics {
+    os_unfair_lock_lock(&_initLock);
+    if (_observersInitialized) {
+        os_unfair_lock_unlock(&_initLock);
+        return;
+    }
     _observersInitialized = YES;
+    os_unfair_lock_unlock(&_initLock);
 
     [self _initializeHealthStore];
 
     if (bridge) self.bridge = bridge;
 
     if ([HKHealthStore isHealthDataAvailable]) {
-        NSArray *fitnessObservers = @[
+        NSArray *allFitnessObservers = @[
             @"ActiveEnergyBurned",
             @"BasalEnergyBurned",
             @"Cycling",
@@ -1107,7 +1132,27 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
             @"SleepAnalysis",
         ];
 
-        for(NSString * type in fitnessObservers) {
+        NSArray *fitnessToRegister;
+        if (metrics.count > 0) {
+            // Convert JS HealthMetric values → native HK type strings
+            NSDictionary *map = [RCTAppleHealthKit healthMetricToHKTypeMap];
+            NSMutableSet *requestedHKTypes = [NSMutableSet set];
+            for (NSString *metric in metrics) {
+                NSString *hkType = map[metric];
+                if (hkType) [requestedHKTypes addObject:hkType];
+            }
+            fitnessToRegister = [allFitnessObservers filteredArrayUsingPredicate:
+                [NSPredicate predicateWithBlock:^BOOL(NSString *type, NSDictionary *_) {
+                    return [requestedHKTypes containsObject:type];
+                }]];
+            NSLog(@"[HealthKit] Registering observers for %lu metrics: %@",
+                  (unsigned long)fitnessToRegister.count,
+                  [fitnessToRegister componentsJoinedByString:@", "]);
+        } else {
+            fitnessToRegister = allFitnessObservers;
+        }
+
+        for (NSString *type in fitnessToRegister) {
             [self fitness_registerObserver:type bridge:bridge];
         }
 
@@ -1122,7 +1167,7 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
             @"VitalSignRecord"
         ];
 
-        for(NSString * type in clinicalObservers) {
+        for (NSString *type in clinicalObservers) {
             [self clinical_registerObserver:type bridge:bridge];
         }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -1107,7 +1107,6 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
         os_unfair_lock_unlock(&_initLock);
         return;
     }
-    os_unfair_lock_unlock(&_initLock);
 
     [self _initializeHealthStore];
 
@@ -1183,7 +1182,6 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
         NSLog(@"[HealthKit] Apple HealthKit is not available in this platform");
     }
 
-    os_unfair_lock_lock(&_initLock);
     _observersInitialized = YES;
     os_unfair_lock_unlock(&_initLock);
 }

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -1081,9 +1081,12 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
  */
   - (void)initializeBackgroundObservers:(RCTBridge *)bridge
 {
+    if (_observersInitialized) return;
+    _observersInitialized = YES;
+
     [self _initializeHealthStore];
 
-    self.bridge = bridge;
+    if (bridge) self.bridge = bridge;
 
     if ([HKHealthStore isHealthDataAvailable]) {
         NSArray *fitnessObservers = @[

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -1146,7 +1146,7 @@ RCT_EXPORT_METHOD(getClinicalVitalRecords:(NSDictionary *)input callback:(RCTRes
 }
 
 - (void)emitEventInternal:(NSNotification *)notification {
-  if (self.hasListeners) {
+  if (self.hasListeners && self.bridge) {
     self.callableJSModules = [RCTAppleHealthKit sharedJsModule];
     [self.callableJSModules setBridge:self.bridge];
     [self sendEventWithName:notification.name


### PR DESCRIPTION
## Description

ticket: [RND-33848](https://helloheart.atlassian.net/browse/RND-33848)

  Problem

  HealthKit background delivery did not work when the app was killed. initializeBackgroundObservers was called lazily from JS
  (configureBackgroundSync), but when iOS wakes a killed app for HealthKit delivery, JS hasn't loaded yet — so no observers were
  registered and iOS got no completionHandler.

  Additionally, calling initializeBackgroundObservers from both AppDelegate (early, nil bridge) and configureBackgroundSync (with
  bridge) registered duplicate HKObserverQuery objects — causing every data change to fire twice.

  Changes

  RCTAppleHealthKit.m — 2 fixes:

  1. nil bridge guard in emitEventInternal
  // Before
  if (self.hasListeners) {
  // After  
  if (self.hasListeners && self.bridge) {
  Prevents crash when initializeBackgroundObservers is called from AppDelegate with nil bridge before JS loads.

  2. _observersInitialized guard moved inside initializeBackgroundObservers
  - (void)initializeBackgroundObservers:(RCTBridge *)bridge {
      if (_observersInitialized) return;  // ← added
      _observersInitialized = YES;        // ← moved here
      if (bridge) self.bridge = bridge;   // ← nil-safe
      ...
  }
  Prevents double-registration when called from both AppDelegate (nil bridge) and configureBackgroundSync (real bridge).

  Usage

  Consuming app calls initializeBackgroundObservers(nil) from AppDelegate.didFinishLaunchingWithOptions before React Native loads.

